### PR TITLE
修复 blame 视图页面被翻译

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -76,7 +76,8 @@
     const blockIds = ["readme", "wiki-content"];
     const blockClass = [
       "CodeMirror",
-      "css-truncate" // 过滤文件目录
+      "css-truncate", // 过滤文件目录
+      "blob-code"
     ];
     const blockTags = ["CODE", "SCRIPT", "LINK", "IMG", "svg", "TABLE", "ARTICLE", "PRE"];
 


### PR DESCRIPTION
示例:https://github.com/maboloshi/BeyondCompare/blame/master/BeyondCompare.py

<img width="919" alt="屏幕截图 2021-05-09 125212" src="https://user-images.githubusercontent.com/7850715/117561010-6eddaf00-b0c5-11eb-85a8-bc171daf0360.png">
