### PR TITLE
修复"文件位置栏"被翻译

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -99,7 +99,8 @@
       "blob-code",
       "topic-tag", // 过滤标签,
       // "text-normal", // 过滤repo name, 复现：https://github.com/search?q=explore
-      "repo-list"//过滤搜索结果项目,解决"text-normal"导致的有些文字不翻译的问题,搜索结果以后可以考虑单独翻译
+      "repo-list",//过滤搜索结果项目,解决"text-normal"导致的有些文字不翻译的问题,搜索结果以后可以考虑单独翻译
+      "breadcrumb", //过滤位置栏
     ];
     const blockTags = ["CODE", "SCRIPT", "LINK", "IMG", "svg", "TABLE", "ARTICLE", "PRE"];
     const blockItemprops = ["name"];

--- a/userscript.js
+++ b/userscript.js
@@ -100,7 +100,8 @@
       "topic-tag", // 过滤标签,
       // "text-normal", // 过滤repo name, 复现：https://github.com/search?q=explore
       "repo-list",//过滤搜索结果项目,解决"text-normal"导致的有些文字不翻译的问题,搜索结果以后可以考虑单独翻译
-      "breadcrumb", //过滤位置栏
+      "breadcrumb", //过滤文件位置栏
+      "d-sm-block", //过滤目录位置栏
     ];
     const blockTags = ["CODE", "SCRIPT", "LINK", "IMG", "svg", "TABLE", "ARTICLE", "PRE"];
     const blockItemprops = ["name"];


### PR DESCRIPTION
浏览模式下:
<img width="596" alt="1" src="https://user-images.githubusercontent.com/7850715/133709013-fd3387be-369d-4f85-a9a2-8e09fe07a776.png">

文件编辑模式下:
<img width="456" alt="2" src="https://user-images.githubusercontent.com/7850715/133709015-1b5bca29-58c0-4b7b-8031-1b9f4f82e511.png">
实测发现，最终文件会被保存到这个**被翻译后的目录**中，而不是原目录

<img width="466" alt="3" src="https://user-images.githubusercontent.com/7850715/133709325-99d06219-ece3-4ee6-8f55-a843f532698e.png">


