### PR TITLE
修复原有`过滤文件位置栏`规则误伤

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -100,7 +100,7 @@
       "topic-tag", // 过滤标签,
       // "text-normal", // 过滤repo name, 复现：https://github.com/search?q=explore
       "repo-list",//过滤搜索结果项目,解决"text-normal"导致的有些文字不翻译的问题,搜索结果以后可以考虑单独翻译
-      "breadcrumb", //过滤文件位置栏
+      "js-path-segment","final-path", //过滤文件位置栏
       "d-sm-block", //过滤目录位置栏
     ];
     const blockTags = ["CODE", "SCRIPT", "LINK", "IMG", "svg", "TABLE", "ARTICLE", "PRE"];


### PR DESCRIPTION
原来:
<img width="948" alt="微信截图_20210924175717" src="https://user-images.githubusercontent.com/7850715/134656521-54eef470-a604-403b-96f4-f8e705a5ab0f.png">

修复后:
<img width="930" alt="微信截图_20210924180116" src="https://user-images.githubusercontent.com/7850715/134656942-59ead936-5d09-4165-a4a0-b485212a63ff.png">


