### PR TITLE
`Watch` 统一翻译为 `关注`

### DIFF
--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -282,8 +282,8 @@
     "star": "星标",
     "unstar": "已加星标",
 
-    "watch": "订阅",
-    "unwatch": "取消订阅",
+    "watch": "关注",
+    "unwatch": "取消关注",
     "participating and @mentions": "参与和 @提及",
     "only receive notifications from this repository when participating or @mentioned.": "仅在参与或 @提及时接收来自此仓库的通知。",
     "all activity": "所有活动",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -1493,7 +1493,7 @@
     "select all": "全选",
     "manage notifications": "管理通知",
     "notification settings": "通知设置",
-    "watched repositories": "订阅的仓库",
+    "watched repositories": "关注的仓库",
     "subscriptions": "订阅",
     "watching": "关注",
     "create new filter": "创建新规则",


### PR DESCRIPTION
## 改动
如题，`Watch` 统一翻译为 `关注` 而非 `订阅`。

## 理由
大部分 `watch` 都被翻译为 `关注`，但小部分为 `订阅`。这应当被统一。